### PR TITLE
Adjust lightbox control spacing

### DIFF
--- a/Product.liquid
+++ b/Product.liquid
@@ -208,6 +208,7 @@
   .pdp-scope #pdp-mainProductImage { aspect-ratio: 4/5; width: 90%; object-fit: cover; display: block; }
   .pdp-scope .mobile-image-strip { display: none; }
   .pdp-scope .product-form { flex: 0 0 50%; }
+  .pdp-scope .pdp-lightbox .controls { gap: 5px; }
 
   .pdp-scope .product-label { font-size: 0.7rem; color: #999; letter-spacing: 1.2px; margin-bottom: 0.4rem; text-transform: uppercase; }
   .pdp-scope .product-title { font-family: "Playfair Display", serif; font-size: 2rem; font-weight: 500; margin-bottom: 0.4rem; letter-spacing: 0.5px; }


### PR DESCRIPTION
## Summary
- reduce the gap between the zoom lightbox controls to 5px so the top-right buttons sit closer together within the PDP scope

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cff00e7df0832f93d301a530d03411