### PR TITLE
Improve zoom interaction handling

### DIFF
--- a/Product.liquid
+++ b/Product.liquid
@@ -362,7 +362,7 @@
     .pdp-scope .product-image { position: sticky; top: 88px; }
   }
   @media (max-width: 768px) {
-    .pdp-scope .product-wrapper { flex-direction: column; padding: 1rem; }
+    .pdp-scope .product-wrapper { flex-direction: column; padding: 1rem; gap: 0; }
     .pdp-scope .product-image, .pdp-scope .product-form { width: 100%; }
     .pdp-scope .product-thumbnails, .pdp-scope #pdp-mainProductImage { display: none !important; }
     .pdp-scope .mobile-image-strip {

--- a/Product.liquid
+++ b/Product.liquid
@@ -414,7 +414,7 @@
     -webkit-user-drag: none;
     will-change: transform;
     opacity: 1;
-    transition: transform 0.12s ease, opacity 0.24s ease;
+    transition: transform var(--pdp-zoom-transform-speed, 0.12s) ease, opacity 0.24s ease;
     transform-origin: 50% 50%;
   }
   .pdp-scope .pdp-zoom-image.is-swapping {
@@ -484,6 +484,27 @@
   .pdp-scope .pdp-lightbox .btn svg {
     width: 15px;
     height: 15px;
+  }
+  .pdp-scope .pdp-lightbox .stage.is-sliding {
+    --pdp-zoom-transform-speed: 0.36s;
+    pointer-events: none;
+  }
+  .pdp-scope .pdp-lightbox .stage.slide-next,
+  .pdp-scope .pdp-lightbox .stage.slide-prev {
+    --pdp-zoom-transform-speed: 0.36s;
+  }
+  .pdp-scope .pdp-lightbox .stage.is-sliding .pdp-zoom-image {
+    cursor: default;
+  }
+  .pdp-scope .pdp-lightbox .slide-clone {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    transition: transform 0.36s ease, opacity 0.24s ease;
+    pointer-events: none;
+    user-select: none;
+    z-index: 2;
   }
   .pdp-scope .pdp-lightbox #pdp-zoomToggle,
   .pdp-scope .pdp-lightbox #pdp-closeZoom {
@@ -835,7 +856,7 @@
       }
 
       const body = document.body;
-      const state = { scale: 1, min: 1, max: 6, tx: 0, ty: 0, baseW: 0, baseH: 0, viewW: 0, viewH: 0 };
+      const state = { scale: 1, min: 1, max: 6, tx: 0, ty: 0, slideOffset: 0, baseW: 0, baseH: 0, viewW: 0, viewH: 0 };
       const viewer = { index: 0, isOpen: false };
       const pts = new Map();
       const clamp = (v, a, b) => Math.min(Math.max(v, a), b);
@@ -848,13 +869,15 @@
       let idleTimer = null;
       let startDrag = null;
       let swipeIntent = null;
+      let activeSlide = null;
       let focusables = [];
       let firstEl = null;
       let lastEl = null;
       let prevActive = null;
 
       const apply = () => {
-        zoomedImage.style.transform = `translate3d(${state.tx}px, ${state.ty}px, 0) scale(${state.scale})`;
+        const slideX = state.slideOffset || 0;
+        zoomedImage.style.transform = `translate3d(${state.tx + slideX}px, ${state.ty}px, 0) scale(${state.scale})`;
         const needsReset = (state.scale > 1.01 || Math.abs(state.tx) > 1 || Math.abs(state.ty) > 1);
         if (zoomToggle) {
           zoomToggle.innerHTML = needsReset ? iconZoomReset : iconZoomIn;
@@ -915,7 +938,10 @@
           dot.type = 'button';
           dot.className = 'dot';
           dot.setAttribute('aria-label', `Go to image ${i + 1}`);
-          dot.addEventListener('click', () => setSlide(i));
+          dot.addEventListener('click', () => {
+            const dir = i === viewer.index ? null : (i > viewer.index ? 'next' : 'prev');
+            setSlide(i, dir);
+          });
           dotsWrap.appendChild(dot);
         });
       }
@@ -931,6 +957,7 @@
         state.scale = 1;
         state.tx = 0;
         state.ty = 0;
+        state.slideOffset = 0;
         schedule();
       }
 
@@ -944,17 +971,36 @@
         schedule();
       }
 
-      function setSlide(index) {
+      function setSlide(index, direction) {
         if (!images.length) {
           return;
         }
-        viewer.index = (index + images.length) % images.length;
+
+        const previousIndex = viewer.index;
+        const rawIndex = typeof index === 'number' ? index : viewer.index;
+        let resolvedDirection = typeof direction === 'string' ? direction : null;
+        const normalizedIndex = (rawIndex + images.length) % images.length;
+
+        if (!resolvedDirection && viewer.isOpen && images.length > 1 && normalizedIndex !== previousIndex) {
+          if (rawIndex > previousIndex || (previousIndex === images.length - 1 && rawIndex >= previousIndex && normalizedIndex === 0)) {
+            resolvedDirection = 'next';
+          } else if (rawIndex < previousIndex || (previousIndex === 0 && rawIndex <= previousIndex && normalizedIndex === images.length - 1)) {
+            resolvedDirection = 'prev';
+          }
+        }
+
+        if (images.length <= 1) {
+          resolvedDirection = null;
+        }
+
+        viewer.index = normalizedIndex;
         const item = images[viewer.index];
         zoomedImage.alt = item.alt || '';
         zoomedImage.removeAttribute('srcset');
         zoomedImage.removeAttribute('sizes');
         counter.textContent = `${viewer.index + 1} / ${images.length}`;
         updateDots();
+
         [viewer.index - 1, viewer.index + 1].forEach((ii) => {
           const neighbor = images[(ii + images.length) % images.length];
           if (neighbor) {
@@ -962,7 +1008,125 @@
             preload.src = neighbor.src;
           }
         });
+
+        const createSlidePrep = (dir) => {
+          const slideClass = dir === 'next' ? 'slide-next' : 'slide-prev';
+          stage.classList.remove('slide-next', 'slide-prev');
+          stage.classList.add('is-sliding', slideClass);
+          stage.querySelectorAll('.slide-clone').forEach((node) => node.remove());
+          const clone = zoomedImage.cloneNode(true);
+          clone.removeAttribute('id');
+          clone.setAttribute('aria-hidden', 'true');
+          clone.classList.add('slide-clone');
+          clone.src = zoomedImage.currentSrc || zoomedImage.src;
+          clone.style.transform = zoomedImage.style.transform;
+          stage.appendChild(clone);
+          zoomedImage.style.visibility = 'hidden';
+          let disposed = false;
+          let finished = false;
+          let cancelClone = null;
+          let fallbackTimer = null;
+
+          const clearStageState = () => {
+            stage.classList.remove('is-sliding', 'slide-next', 'slide-prev');
+            zoomedImage.style.visibility = '';
+            state.slideOffset = 0;
+          };
+
+          return {
+            start(onComplete) {
+              if (disposed) {
+                onComplete?.();
+                return () => {};
+              }
+              const rect = stage.getBoundingClientRect();
+              const distance = Math.max(rect.width || state.viewW || window.innerWidth || 1, 1);
+              const offset = dir === 'next' ? distance : -distance;
+              const prevTransition = zoomedImage.style.transition;
+              zoomedImage.style.transition = 'none';
+              state.slideOffset = offset;
+              clampPan();
+              apply();
+              void zoomedImage.offsetWidth;
+              zoomedImage.style.transition = prevTransition;
+              zoomedImage.style.visibility = '';
+              requestAnimationFrame(() => {
+                state.slideOffset = 0;
+                clampPan();
+                apply();
+              });
+
+              clone.style.transition = 'transform 0.36s ease';
+              clone.style.transform = `translate3d(${state.tx}px, ${state.ty}px, 0) scale(${state.scale})`;
+              void clone.offsetWidth;
+              requestAnimationFrame(() => {
+                clone.style.transform = `translate3d(${state.tx - offset}px, ${state.ty}px, 0) scale(${state.scale})`;
+              });
+
+              const finish = () => {
+                if (finished) return;
+                finished = true;
+                clearTimeout(fallbackTimer);
+                clone.remove();
+                onComplete?.();
+              };
+              const handleCloneEnd = () => {
+                clone.removeEventListener('transitionend', handleCloneEnd);
+                finish();
+              };
+              clone.addEventListener('transitionend', handleCloneEnd);
+              fallbackTimer = setTimeout(finish, 420);
+
+              cancelClone = () => {
+                clone.removeEventListener('transitionend', handleCloneEnd);
+                clearTimeout(fallbackTimer);
+                clone.remove();
+                finished = true;
+              };
+
+              return cancelClone;
+            },
+            cleanup(force = false) {
+              if (disposed) return;
+              disposed = true;
+              clearTimeout(fallbackTimer);
+              if (force && !finished) {
+                cancelClone?.();
+              }
+              clone.remove();
+              clearStageState();
+            }
+          };
+        };
+
+        if (activeSlide) {
+          activeSlide.cleanup(true);
+          activeSlide = null;
+        }
+
+        let slidePrep = null;
+        if (resolvedDirection) {
+          state.scale = 1;
+          state.tx = 0;
+          state.ty = 0;
+          state.slideOffset = 0;
+          clampPan();
+          apply();
+          slidePrep = createSlidePrep(resolvedDirection);
+          activeSlide = slidePrep;
+        } else {
+          zoomedImage.classList.add('is-swapping');
+        }
+
+        let animationDone = !resolvedDirection;
+        let imageReady = false;
+        let releaseSlide = null;
+
         const finalizeSwap = () => {
+          if (slidePrep && activeSlide === slidePrep) {
+            slidePrep.cleanup();
+            activeSlide = null;
+          }
           measureBase();
           resetView();
           requestAnimationFrame(() => {
@@ -970,32 +1134,55 @@
           });
         };
 
-        const beginSwap = () => {
-          zoomedImage.classList.add('is-swapping');
-          const handleLoad = () => {
-            zoomedImage.removeEventListener('error', handleError);
+        const maybeFinish = () => {
+          if (animationDone && imageReady) {
+            releaseSlide?.();
+            releaseSlide = null;
             finalizeSwap();
-          };
-          const handleError = () => {
-            zoomedImage.removeEventListener('load', handleLoad);
-            requestAnimationFrame(() => {
-              zoomedImage.classList.remove('is-swapping');
-            });
-          };
-          zoomedImage.addEventListener('load', handleLoad, { once: true });
-          zoomedImage.addEventListener('error', handleError, { once: true });
-          zoomedImage.src = item.src;
-          if (zoomedImage.complete && zoomedImage.naturalWidth > 0) {
-            handleLoad();
+          }
+        };
+
+        const handleLoad = () => {
+          zoomedImage.removeEventListener('error', handleError);
+          imageReady = true;
+          if (slidePrep) {
+            releaseSlide = slidePrep.start(() => {
+              animationDone = true;
+              maybeFinish();
+            }) || null;
+          } else {
+            animationDone = true;
+            maybeFinish();
+          }
+        };
+
+        const handleError = () => {
+          zoomedImage.removeEventListener('load', handleLoad);
+          slidePrep?.cleanup(true);
+          if (activeSlide === slidePrep) {
+            activeSlide = null;
+          }
+          zoomedImage.classList.remove('is-swapping');
+          zoomedImage.style.visibility = '';
+          const fallback = images[previousIndex];
+          if (fallback) {
+            viewer.index = previousIndex;
+            counter.textContent = `${viewer.index + 1} / ${images.length}`;
+            updateDots();
+            zoomedImage.alt = fallback.alt || '';
+            zoomedImage.src = fallback.src;
+            measureBase();
+            resetView();
           }
         };
 
         zoomedImage.onload = null;
         zoomedImage.onerror = null;
-        if (zoomedImage.src !== item.src) {
-          beginSwap();
-        } else {
-          finalizeSwap();
+        zoomedImage.addEventListener('load', handleLoad, { once: true });
+        zoomedImage.addEventListener('error', handleError, { once: true });
+        zoomedImage.src = item.src;
+        if (zoomedImage.complete && zoomedImage.naturalWidth > 0) {
+          handleLoad();
         }
         showUI();
       }
@@ -1035,8 +1222,8 @@
           zoomAt(0, 0, quickZoomScale());
         }
       });
-      prevBtn.addEventListener('click', () => setSlide(viewer.index - 1));
-      nextBtn.addEventListener('click', () => setSlide(viewer.index + 1));
+      prevBtn.addEventListener('click', () => setSlide(viewer.index - 1, 'prev'));
+      nextBtn.addEventListener('click', () => setSlide(viewer.index + 1, 'next'));
 
       lightbox.addEventListener('mousemove', showUI);
       lightbox.addEventListener('click', (event) => {
@@ -1050,10 +1237,10 @@
           closeLightbox();
         } else if (event.key === 'ArrowRight') {
           event.preventDefault();
-          setSlide(viewer.index + 1);
+          setSlide(viewer.index + 1, 'next');
         } else if (event.key === 'ArrowLeft') {
           event.preventDefault();
-          setSlide(viewer.index - 1);
+          setSlide(viewer.index - 1, 'prev');
         } else if (event.key === '+' || (event.key === '=' && (event.ctrlKey || event.metaKey))) {
           event.preventDefault();
           zoomAt(0, 0, state.scale * 1.25);
@@ -1137,7 +1324,7 @@
         if (!pts.size) {
           swipeIntent = null;
           if (dragSnapshot && dragSnapshot.atScale === 1 && state.scale === 1 && intent) {
-            setSlide(viewer.index + (intent === 'next' ? 1 : -1));
+            setSlide(viewer.index + (intent === 'next' ? 1 : -1), intent);
           }
           lightbox.classList.remove('dragging');
           startDrag = null;

--- a/Product.liquid
+++ b/Product.liquid
@@ -862,6 +862,7 @@
       const clamp = (v, a, b) => Math.min(Math.max(v, a), b);
       const SWIPE_HORIZONTAL_THRESHOLD = 48;
       const SWIPE_VERTICAL_LIMIT = 40;
+      const HYSTERESIS = 8; // px
       const quickZoomScale = () => Math.min(3, state.max);
       let images = [];
       let pinchStart = null;
@@ -877,12 +878,13 @@
 
       const apply = () => {
         const slideX = state.slideOffset || 0;
-        zoomedImage.style.transform = `translate3d(${state.tx + slideX}px, ${state.ty}px, 0) scale(${state.scale})`;
+        zoomedImage.style.transform =
+          `translate3d(${state.tx + slideX}px, ${state.ty}px, 0) scale(${state.scale})`;
         const needsReset = (state.scale > 1.01 || Math.abs(state.tx) > 1 || Math.abs(state.ty) > 1);
         if (zoomToggle) {
           zoomToggle.innerHTML = needsReset ? iconZoomReset : iconZoomIn;
+          zoomToggle.setAttribute('aria-label', needsReset ? 'Reset zoom' : 'Zoom in');
         }
-        zoomToggle.setAttribute('aria-label', needsReset ? 'Reset zoom' : 'Zoom in');
       };
 
       const clampPan = () => {
@@ -1012,7 +1014,6 @@
         const createSlidePrep = (dir) => {
           const slideClass = dir === 'next' ? 'slide-next' : 'slide-prev';
           stage.classList.remove('slide-next', 'slide-prev');
-          stage.classList.add('is-sliding', slideClass);
           stage.querySelectorAll('.slide-clone').forEach((node) => node.remove());
           const clone = zoomedImage.cloneNode(true);
           clone.removeAttribute('id');
@@ -1042,14 +1043,14 @@
               const rect = stage.getBoundingClientRect();
               const distance = Math.max(rect.width || state.viewW || window.innerWidth || 1, 1);
               const offset = dir === 'next' ? distance : -distance;
-              const prevTransition = zoomedImage.style.transition;
               zoomedImage.style.transition = 'none';
               state.slideOffset = offset;
               clampPan();
               apply();
               void zoomedImage.offsetWidth;
-              zoomedImage.style.transition = prevTransition;
+              zoomedImage.style.transition = '';
               zoomedImage.style.visibility = '';
+              stage.classList.add('is-sliding', slideClass);
               requestAnimationFrame(() => {
                 state.slideOffset = 0;
                 clampPan();
@@ -1120,7 +1121,6 @@
 
         let animationDone = !resolvedDirection;
         let imageReady = false;
-        let releaseSlide = null;
 
         const finalizeSwap = () => {
           if (slidePrep && activeSlide === slidePrep) {
@@ -1136,8 +1136,6 @@
 
         const maybeFinish = () => {
           if (animationDone && imageReady) {
-            releaseSlide?.();
-            releaseSlide = null;
             finalizeSwap();
           }
         };
@@ -1146,10 +1144,10 @@
           zoomedImage.removeEventListener('error', handleError);
           imageReady = true;
           if (slidePrep) {
-            releaseSlide = slidePrep.start(() => {
+            slidePrep.start(() => {
               animationDone = true;
               maybeFinish();
-            }) || null;
+            });
           } else {
             animationDone = true;
             maybeFinish();
@@ -1197,9 +1195,13 @@
         body.dataset.prevOverflow = body.style.overflow || '';
         body.style.overflow = 'hidden';
         prevActive = opener || document.activeElement;
-        setSlide(index);
-        trapFocus();
-        zoomToggle.focus();
+
+        requestAnimationFrame(() => {
+          measureBase();
+          setSlide(index);
+          trapFocus();
+          zoomToggle?.focus();
+        });
       }
 
       function closeLightbox() {
@@ -1298,9 +1300,15 @@
           } else {
             const dx = current.x - startDrag.x;
             const dy = current.y - startDrag.y;
-            if (Math.abs(dy) <= SWIPE_VERTICAL_LIMIT && Math.abs(dx) >= SWIPE_HORIZONTAL_THRESHOLD) {
+            if (
+              Math.abs(dy) <= SWIPE_VERTICAL_LIMIT &&
+              Math.abs(dx) >= SWIPE_HORIZONTAL_THRESHOLD + HYSTERESIS
+            ) {
               swipeIntent = dx < 0 ? 'next' : 'prev';
-            } else if (Math.abs(dx) < SWIPE_HORIZONTAL_THRESHOLD || Math.abs(dy) > SWIPE_VERTICAL_LIMIT) {
+            } else if (
+              Math.abs(dx) < SWIPE_HORIZONTAL_THRESHOLD ||
+              Math.abs(dy) > SWIPE_VERTICAL_LIMIT
+            ) {
               swipeIntent = null;
             }
           }

--- a/Product.liquid
+++ b/Product.liquid
@@ -1020,7 +1020,11 @@
           clone.setAttribute('aria-hidden', 'true');
           clone.classList.add('slide-clone');
           clone.src = zoomedImage.currentSrc || zoomedImage.src;
-          clone.style.transform = zoomedImage.style.transform;
+          const applyClone = (deltaX = 0) => {
+            clone.style.transform =
+              `translate3d(-50%, -50%, 0) translate3d(${state.tx + deltaX}px, ${state.ty}px, 0) scale(${state.scale})`;
+          };
+          applyClone();
           stage.appendChild(clone);
           zoomedImage.style.visibility = 'hidden';
           let disposed = false;
@@ -1057,11 +1061,12 @@
                 apply();
               });
 
-              clone.style.transition = 'transform 0.36s ease';
-              clone.style.transform = `translate3d(${state.tx}px, ${state.ty}px, 0) scale(${state.scale})`;
+              clone.style.transition = 'none';
+              applyClone();
               void clone.offsetWidth;
+              clone.style.transition = '';
               requestAnimationFrame(() => {
-                clone.style.transform = `translate3d(${state.tx - offset}px, ${state.ty}px, 0) scale(${state.scale})`;
+                applyClone(-offset);
               });
 
               const finish = () => {

--- a/Product.liquid
+++ b/Product.liquid
@@ -200,13 +200,13 @@
       <div class="counter" id="pdp-zoomCounter" aria-live="polite"></div>
       <div class="controls">
         <button class="btn" type="button" id="pdp-zoomToggle" aria-label="Zoom in">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <svg width="15" height="15" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
             <path d="M10 4V16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
             <path d="M4 10H16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
           </svg>
         </button>
         <button class="btn" type="button" id="pdp-closeZoom" aria-label="Close">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <svg width="15" height="15" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
             <path d="M5 5L15 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
             <path d="M15 5L5 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
           </svg>
@@ -214,12 +214,12 @@
       </div>
       <div class="side-nav">
         <button class="btn" type="button" id="pdp-prevZoom" aria-label="Previous image">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <svg width="15" height="15" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
             <path d="M12.5 5L7.5 10L12.5 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
         <button class="btn" type="button" id="pdp-nextZoom" aria-label="Next image">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+          <svg width="15" height="15" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
             <path d="M7.5 5L12.5 10L7.5 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
@@ -413,8 +413,12 @@
     user-select: none;
     -webkit-user-drag: none;
     will-change: transform;
-    transition: transform 0.12s ease;
+    opacity: 1;
+    transition: transform 0.12s ease, opacity 0.24s ease;
     transform-origin: 50% 50%;
+  }
+  .pdp-scope .pdp-zoom-image.is-swapping {
+    opacity: 0;
   }
   .pdp-scope .pdp-lightbox.dragging .pdp-zoom-image {
     cursor: grabbing;
@@ -478,8 +482,12 @@
     box-shadow: none;
   }
   .pdp-scope .pdp-lightbox .btn svg {
-    width: 20px;
-    height: 20px;
+    width: 15px;
+    height: 15px;
+  }
+  .pdp-scope .pdp-lightbox #pdp-zoomToggle,
+  .pdp-scope .pdp-lightbox #pdp-closeZoom {
+    margin: 0;
   }
   .pdp-scope .pdp-lightbox .btn:hover { background: var(--pdp-zoom-btn-bg-hover); }
   .pdp-scope .pdp-lightbox .btn:active { transform: scale(0.96); }
@@ -816,7 +824,7 @@
       const dotsWrap = scope.querySelector('#pdp-zoomDots');
       const counter = scope.querySelector('#pdp-zoomCounter');
       const iconZoomIn = zoomToggle ? zoomToggle.innerHTML.trim() : '';
-      const iconZoomReset = '<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M4 10H16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>';
+      const iconZoomReset = '<svg width="15" height="15" viewBox="0 0 20 20" fill="none" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path d="M4 10H16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>';
 
       if (!lightbox || !stage || !zoomedImage || !zoomToggle || !closeBtn || !prevBtn || !nextBtn || !dotsWrap || !counter) {
         return {
@@ -827,15 +835,19 @@
       }
 
       const body = document.body;
-      const state = { scale: 1, min: 1, max: 4, tx: 0, ty: 0, baseW: 0, baseH: 0, viewW: 0, viewH: 0 };
+      const state = { scale: 1, min: 1, max: 6, tx: 0, ty: 0, baseW: 0, baseH: 0, viewW: 0, viewH: 0 };
       const viewer = { index: 0, isOpen: false };
       const pts = new Map();
       const clamp = (v, a, b) => Math.min(Math.max(v, a), b);
+      const SWIPE_HORIZONTAL_THRESHOLD = 48;
+      const SWIPE_VERTICAL_LIMIT = 40;
+      const quickZoomScale = () => Math.min(3, state.max);
       let images = [];
       let pinchStart = null;
       let raf = null;
       let idleTimer = null;
       let startDrag = null;
+      let swipeIntent = null;
       let focusables = [];
       let firstEl = null;
       let lastEl = null;
@@ -855,8 +867,12 @@
         const contentH = state.baseH * state.scale;
         const maxX = Math.max(0, (contentW - state.viewW) / 2);
         const maxY = Math.max(0, (contentH - state.viewH) / 2);
-        state.tx = clamp(state.tx, -maxX, maxX);
-        state.ty = clamp(state.ty, -maxY, maxY);
+        const allowOvershoot = lightbox.classList.contains('dragging') && state.scale > 1;
+        const overshootFactor = allowOvershoot ? 0.18 : 0;
+        const bufferX = allowOvershoot ? Math.min(state.viewW * overshootFactor, 140) : 0;
+        const bufferY = allowOvershoot ? Math.min(state.viewH * overshootFactor, 140) : 0;
+        state.tx = clamp(state.tx, -maxX - bufferX, maxX + bufferX);
+        state.ty = clamp(state.ty, -maxY - bufferY, maxY + bufferY);
       };
 
       const schedule = () => {
@@ -882,7 +898,7 @@
         if (zoomedImage.naturalWidth && state.baseW) {
           const limitW = zoomedImage.naturalWidth / state.baseW;
           const limitH = zoomedImage.naturalHeight / state.baseH;
-          state.max = Math.max(1, Math.min(4, limitW, limitH));
+          state.max = Math.max(1, Math.min(6, limitW, limitH));
         }
       }
 
@@ -937,9 +953,6 @@
         zoomedImage.alt = item.alt || '';
         zoomedImage.removeAttribute('srcset');
         zoomedImage.removeAttribute('sizes');
-        if (zoomedImage.src !== item.src) {
-          zoomedImage.src = item.src;
-        }
         counter.textContent = `${viewer.index + 1} / ${images.length}`;
         updateDots();
         [viewer.index - 1, viewer.index + 1].forEach((ii) => {
@@ -949,15 +962,40 @@
             preload.src = neighbor.src;
           }
         });
-        if (zoomedImage.complete && zoomedImage.naturalWidth > 0) {
+        const finalizeSwap = () => {
           measureBase();
           resetView();
-        } else {
-          zoomedImage.onload = () => {
-            measureBase();
-            resetView();
-            zoomedImage.onload = null;
+          requestAnimationFrame(() => {
+            zoomedImage.classList.remove('is-swapping');
+          });
+        };
+
+        const beginSwap = () => {
+          zoomedImage.classList.add('is-swapping');
+          const handleLoad = () => {
+            zoomedImage.removeEventListener('error', handleError);
+            finalizeSwap();
           };
+          const handleError = () => {
+            zoomedImage.removeEventListener('load', handleLoad);
+            requestAnimationFrame(() => {
+              zoomedImage.classList.remove('is-swapping');
+            });
+          };
+          zoomedImage.addEventListener('load', handleLoad, { once: true });
+          zoomedImage.addEventListener('error', handleError, { once: true });
+          zoomedImage.src = item.src;
+          if (zoomedImage.complete && zoomedImage.naturalWidth > 0) {
+            handleLoad();
+          }
+        };
+
+        zoomedImage.onload = null;
+        zoomedImage.onerror = null;
+        if (zoomedImage.src !== item.src) {
+          beginSwap();
+        } else {
+          finalizeSwap();
         }
         showUI();
       }
@@ -994,7 +1032,7 @@
         if (state.scale > 1.01 || Math.abs(state.tx) > 1 || Math.abs(state.ty) > 1) {
           resetView();
         } else {
-          zoomAt(0, 0, Math.min(2, state.max));
+          zoomAt(0, 0, quickZoomScale());
         }
       });
       prevBtn.addEventListener('click', () => setSlide(viewer.index - 1));
@@ -1029,7 +1067,7 @@
         const rect = stage.getBoundingClientRect();
         const cx = event.clientX - (rect.left + rect.width / 2);
         const cy = event.clientY - (rect.top + rect.height / 2);
-        const targetScale = state.scale > 1 ? 1 : Math.min(2, state.max);
+        const targetScale = state.scale > 1 ? 1 : quickZoomScale();
         zoomAt(cx, cy, targetScale);
       });
 
@@ -1039,8 +1077,11 @@
         pts.set(event.pointerId, { x: event.clientX, y: event.clientY });
         if (pts.size === 1) {
           startDrag = { x: event.clientX, y: event.clientY, atScale: state.scale };
+          swipeIntent = null;
         }
         if (pts.size === 2) {
+          startDrag = null;
+          swipeIntent = null;
           const [a, b] = [...pts.values()];
           const dx = b.x - a.x;
           const dy = b.y - a.y;
@@ -1060,19 +1101,22 @@
         const current = { x: event.clientX, y: event.clientY };
         pts.set(event.pointerId, current);
 
-        if (pts.size === 1) {
-          if (state.scale === 1 && startDrag) {
+        if (pts.size === 1 && startDrag) {
+          const zoomedNow = state.scale > 1.001;
+          const startedZoomed = startDrag.atScale > 1.001;
+          if (zoomedNow || startedZoomed) {
+            state.tx += current.x - previous.x;
+            state.ty += current.y - previous.y;
+            schedule();
+          } else {
             const dx = current.x - startDrag.x;
             const dy = current.y - startDrag.y;
-            if (Math.abs(dx) > 48 && Math.abs(dy) < 40) {
-              setSlide(viewer.index + (dx < 0 ? 1 : -1));
-              startDrag = { x: current.x, y: current.y, atScale: 1 };
-              return;
+            if (Math.abs(dy) <= SWIPE_VERTICAL_LIMIT && Math.abs(dx) >= SWIPE_HORIZONTAL_THRESHOLD) {
+              swipeIntent = dx < 0 ? 'next' : 'prev';
+            } else if (Math.abs(dx) < SWIPE_HORIZONTAL_THRESHOLD || Math.abs(dy) > SWIPE_VERTICAL_LIMIT) {
+              swipeIntent = null;
             }
           }
-          state.tx += current.x - previous.x;
-          state.ty += current.y - previous.y;
-          schedule();
         } else if (pts.size === 2 && pinchStart) {
           const [a, b] = [...pts.values()];
           const dx = b.x - a.x;
@@ -1085,11 +1129,26 @@
 
       const endPointer = (event) => {
         if (!pts.has(event.pointerId)) return;
+        const dragSnapshot = startDrag;
+        const intent = swipeIntent;
         pts.delete(event.pointerId);
         if (pts.size < 2) pinchStart = null;
+
         if (!pts.size) {
+          swipeIntent = null;
+          if (dragSnapshot && dragSnapshot.atScale === 1 && state.scale === 1 && intent) {
+            setSlide(viewer.index + (intent === 'next' ? 1 : -1));
+          }
           lightbox.classList.remove('dragging');
           startDrag = null;
+          schedule();
+        } else if (pts.size === 1) {
+          const [, point] = pts.entries().next().value;
+          startDrag = { x: point.x, y: point.y, atScale: state.scale };
+          swipeIntent = null;
+        } else {
+          startDrag = null;
+          swipeIntent = null;
         }
       };
       stage.addEventListener('pointerup', endPointer);


### PR DESCRIPTION
## Summary
- scope the zero-margin override to the zoom and close buttons so other controls retain the base spacing
- add a fade transition around slide swaps so zoomed images crossfade smoothly
- raise the zoom ceiling with a gentler pan clamp that defers slide changes until swipe release

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0dfe6c5f0832fb7e5cb59b0c73fb9